### PR TITLE
Add variable name rule for eslint & viewer backend

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = {
 
     // React Stateless Component 작성시 PascalCase를 사용하기 위해 허용한다.
     // 참고: https://github.com/palantir/tslint-react/issues/120
-    'variable-name': [true, 'allow-pascal-case', "allow-snake-case"],
+    'variable-name': [true, 'allow-pascal-case', 'allow-snake-case'],
 
     // `@ridi/eslint-configs` 모듈과 일관성을 위해 세미콜론은 항상 사용한다.
     'semicolon': [true, 'always'],

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = {
 
     // React Stateless Component 작성시 PascalCase를 사용하기 위해 허용한다.
     // 참고: https://github.com/palantir/tslint-react/issues/120
-    'variable-name': [true, 'allow-pascal-case'],
+    'variable-name': [true, 'allow-pascal-case', "allow-snake-case"],
 
     // `@ridi/eslint-configs` 모듈과 일관성을 위해 세미콜론은 항상 사용한다.
     'semicolon': [true, 'always'],


### PR DESCRIPTION
안녕하세요 뷰어팀 박현준입니다.
현재 [ridi/eslint](https://github.com/ridi/eslint-config/blob/master/index.js#L4) 에서도 변수명을 camelCase를 강제하지 않으며,

[뷰어팀 백엔드 가이드](https://ridicorp.atlassian.net/wiki/spaces/DevSpace/pages/829752034) 가이드에서 snake_case를 권장하고 있습니다. 따라서 해당 옵션을 추가해주셨으면 좋겠습니다. 감사합니다.